### PR TITLE
Add clues for more descriptive tests

### DIFF
--- a/src/main/scala/nl/biopet/utils/test/tools/ToolTest.scala
+++ b/src/main/scala/nl/biopet/utils/test/tools/ToolTest.scala
@@ -11,8 +11,10 @@ trait ToolTest[T] extends BiopetTest {
   def testArgs(): Unit = {
 
     for (option <- toolCommand.argsParser.optionsForRender){
-      option.desc should not be empty
-      option.desc.length() should be > 10
+      withClue(s"'${option.fullName}' description: ") {
+        option.desc should not be empty
+        option.desc.length() should be > 10
+      }
     }
   }
 }

--- a/src/test/scala/nl/biopet/utils/test/tools/ToolTestTest.scala
+++ b/src/test/scala/nl/biopet/utils/test/tools/ToolTestTest.scala
@@ -32,7 +32,7 @@ class ToolTestTest extends BiopetTest {
     val noDescriptionTest = new NoDescriptionOption()
     intercept[TestFailedException] {
       noDescriptionTest.testArgs()
-    }.getMessage shouldBe "\"\" was empty"
+    }.getMessage shouldBe "'--num' description: \"\" was empty"
   }
 
   @Test
@@ -48,7 +48,7 @@ class ToolTestTest extends BiopetTest {
     val shortDescriptionTest = new ShortDescriptionOption()
     intercept[TestFailedException] {
       shortDescriptionTest.testArgs()
-    }.getMessage shouldBe "7 was not greater than 10"
+    }.getMessage shouldBe "'--num' description: 7 was not greater than 10"
   }
 
   @Test


### PR DESCRIPTION
`--option` instead of plain `option` because it shows more clearly that an option test is failing. 

### Checklist (never delete this)

- [ ] Each method/class/object/trait should have scaladocs
- [ ] Added methods are unit tested
- [ ] Test coverage may not drop
- [ ] Documentation should be updated if required
