### PR TITLE
Write tests to enforce certain word counts in documentation

### DIFF
--- a/src/main/scala/nl/biopet/utils/test/tools/ToolTest.scala
+++ b/src/main/scala/nl/biopet/utils/test/tools/ToolTest.scala
@@ -17,4 +17,16 @@ trait ToolTest[T] extends BiopetTest {
       }
     }
   }
+  @Test
+  def testDocs(): Unit = {
+    val descriptionWords = toolCommand.descriptionText.split("\\s+").length
+    val manualWords = toolCommand.manualText.split("\\s+").length
+    val exampleWords = toolCommand.exampleText.split("\\s+").length
+
+    descriptionWords should be >= 25
+    descriptionWords should be <= 250
+
+    manualWords should be >= 25
+    exampleWords should be >= 25
+  }
 }

--- a/src/test/scala/nl/biopet/utils/test/tools/ToolTestTest.scala
+++ b/src/test/scala/nl/biopet/utils/test/tools/ToolTestTest.scala
@@ -9,6 +9,14 @@ import org.testng.annotations.Test
 
 class ToolTestTest extends BiopetTest {
 
+  val loremIpsum =
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+      |incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+      |exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+      |dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+      |Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      |anim id est laborum.""".stripMargin
+
   case class Args(num: Int = 0,
                   inputFile: File = null,
                   someBoolean: Boolean = false)
@@ -26,6 +34,9 @@ class ToolTestTest extends BiopetTest {
         def argsParser: AbstractOptParser[Args] = new AbstractOptParser[Args]("test") {
           opt[Int]('n', "num") action { (x, c) => c.copy(num = x) }
         }
+        def descriptionText = loremIpsum
+        def manualText = loremIpsum
+        def exampleText = loremIpsum
       }
     }
 
@@ -42,6 +53,9 @@ class ToolTestTest extends BiopetTest {
         def argsParser: AbstractOptParser[Args] = new AbstractOptParser[Args]("test") {
           opt[Int]('n', "num") text "Bla bla" action { (x, c) => c.copy(num = x) }
         }
+        def descriptionText = loremIpsum
+        def manualText = loremIpsum
+        def exampleText = loremIpsum
       }
     }
 
@@ -52,12 +66,12 @@ class ToolTestTest extends BiopetTest {
   }
 
   @Test
-  def validOption(): Unit = {
+  def validTool(): Unit = {
     class ValidOption() extends ToolTest[Args] {
       def toolCommand: ToolCommand[Args] = new TestTool {
         def argsParser: AbstractOptParser[Args] = new AbstractOptParser[Args]("test") {
           opt[Int]('n', "num") text "This is a numeric value" action { (x, c) => c.copy(num = x) }
-          opt[File]('I', "inputFile") required() unbounded() maxOccurs 1 valueName "<file>" action {
+          opt[File]('I', "inputFile") required() maxOccurs 1 valueName "<file>" action {
             (x, c) =>
               c.copy(inputFile = x.getAbsoluteFile)
           } validate { x =>
@@ -67,11 +81,103 @@ class ToolTestTest extends BiopetTest {
             c.copy(someBoolean = true)
           }
         }
+        def descriptionText = loremIpsum
+        def manualText = loremIpsum
+        def exampleText = loremIpsum
       }
 
-      val ValidOptionTest = new ValidOption()
-      ValidOptionTest.testArgs()
+      val validToolTest = new ValidOption()
+      validToolTest.testArgs()
+      validToolTest.testDocs()
     }
+  }
+
+  @Test
+  def descriptionTextTooShort(): Unit = {
+    class ShortDescriptionText() extends ToolTest[Args] {
+      def toolCommand: ToolCommand[Args] = new TestTool {
+        def argsParser: AbstractOptParser[Args] = new AbstractOptParser[Args]("test") {
+          opt[Int]('n', "num") text "This is a numeric value" action { (x, c) => c.copy(num = x) }
+        }
+
+
+        def descriptionText = "Way too short."
+
+        def manualText = loremIpsum
+
+        def exampleText = loremIpsum
+      }
+    }
+    val shortDescriptionTest = new ShortDescriptionText()
+    intercept[TestFailedException] {
+      shortDescriptionTest.testDocs()
+    }.getMessage shouldBe "3 was not greater than or equal to 25"
+  }
+
+  @Test
+  def descriptionTextTooLong(): Unit = {
+    class LongDescriptionText() extends ToolTest[Args] {
+      def toolCommand: ToolCommand[Args] = new TestTool {
+        def argsParser: AbstractOptParser[Args] = new AbstractOptParser[Args]("test") {
+          opt[Int]('n', "num") text "This is a numeric value" action { (x, c) => c.copy(num = x) }
+        }
+
+
+        def descriptionText = loremIpsum * 10
+
+        def manualText = loremIpsum
+
+        def exampleText = loremIpsum
+      }
+    }
+    val longDescriptionTest = new LongDescriptionText()
+    intercept[TestFailedException] {
+      longDescriptionTest.testDocs()
+    }.getMessage shouldBe "681 was not less than or equal to 250"
+  }
+
+  @Test
+  def manualTextTooShort(): Unit = {
+    class ShortManualText() extends ToolTest[Args] {
+      def toolCommand: ToolCommand[Args] = new TestTool {
+        def argsParser: AbstractOptParser[Args] = new AbstractOptParser[Args]("test") {
+          opt[Int]('n', "num") text "This is a numeric value" action { (x, c) => c.copy(num = x) }
+        }
+
+
+        def descriptionText = loremIpsum
+
+        def manualText = "Way too short."
+
+        def exampleText = loremIpsum
+      }
+    }
+    val shortManualTest = new ShortManualText()
+    intercept[TestFailedException] {
+      shortManualTest.testDocs()
+    }.getMessage shouldBe "3 was not greater than or equal to 25"
+  }
+
+  @Test
+  def exampleTextTooShort(): Unit = {
+    class ShortExampleText() extends ToolTest[Args] {
+      def toolCommand: ToolCommand[Args] = new TestTool {
+        def argsParser: AbstractOptParser[Args] = new AbstractOptParser[Args]("test") {
+          opt[Int]('n', "num") text "This is a numeric value" action { (x, c) => c.copy(num = x) }
+        }
+
+
+        def descriptionText = loremIpsum
+
+        def manualText = loremIpsum
+
+        def exampleText = "Way too short."
+      }
+    }
+    val shortExampleTest = new ShortExampleText()
+    intercept[TestFailedException] {
+      shortExampleTest.testDocs()
+    }.getMessage shouldBe "3 was not greater than or equal to 25"
   }
 }
 


### PR DESCRIPTION
### Description

Word counts:
25 < descriptionText < 250 
manualText > 25
exampleText > 25


### Checklist (never delete this)

- [ ] Each method/class/object/trait should have scaladocs
- [ ] Added methods are unit tested
- [ ] Test coverage may not drop
- [ ] Documentation should be updated if required
